### PR TITLE
chore: Verify by file

### DIFF
--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -20,7 +20,7 @@ jobs:
           TestVectorsAwsCryptographicMaterialProviders,
           StandardLibrary,
         ]
-        os: [ macos-latest ]
+        os: [ macos-latest-large ]
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -40,6 +40,13 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
+      # dafny-reportgenerator requires next6
+      # but only 7.0 is installed on macos-latest-large
+      - name: Setup .NET Core SDK '6.0.x'
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Verify ${{ matrix.library }} Dafny code
         shell: bash
         working-directory: ./${{ matrix.library }}
@@ -48,12 +55,8 @@ jobs:
           CORES=$(node -e 'console.log(os.cpus().length)')
           make verify CORES=$CORES
 
-      - name: Setup .NET Core SDK '6.0.x'
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '6.0.x'
-
       - name: Check solver resource use
+        if: success() || failure()
         shell: bash
         working-directory: ./${{ matrix.library }}
         run: |

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -20,7 +20,7 @@ jobs:
           AwsCryptographicMaterialProviders, 
           StandardLibrary,
         ]
-        os: [ macos-latest-large ]
+        os: [ temporary-performance-testing_ubuntu-latest_64-core ]
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -20,7 +20,7 @@ jobs:
           AwsCryptographicMaterialProviders, 
           StandardLibrary,
         ]
-        os: [ temporary-performance-testing_ubuntu-latest_64-core ]
+        os: [ macos-latest-large ]
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -48,10 +48,10 @@ jobs:
           CORES=$(node -e 'console.log(os.cpus().length)')
           make verify CORES=$CORES
 
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+      - name: Setup .NET Core SDK '6.0.x'
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: '6.0.x'
 
       - name: Check solver resource use
         shell: bash

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       matrix:
         library: [
+          TestVectorsAwsCryptographicMaterialProviders,
           AwsCryptographyPrimitives,
           ComAmazonawsKms,
           ComAmazonawsDynamodb,
           AwsCryptographicMaterialProviders, 
-          TestVectorsAwsCryptographicMaterialProviders,
           StandardLibrary,
         ]
         os: [ macos-latest-large ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -48,6 +48,11 @@ jobs:
           CORES=$(node -e 'console.log(os.cpus().length)')
           make verify CORES=$CORES
 
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
       - name: Check solver resource use
         shell: bash
         working-directory: ./${{ matrix.library }}

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
@@ -514,6 +514,7 @@ module AwsKmsMrkKeyring {
                                                                     message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
 
       assert decryptClosure.Ensures(Last(attempts).input, Success(SealedDecryptionMaterials), DropLast(attempts));
+      assert Last(attempts).input in input.encryptedDataKeys;
 
       return Success(Types.OnDecryptOutput(
                        materials := SealedDecryptionMaterials

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -66,7 +66,7 @@ COMPILE_SUFFIX_OPTION := -compileSuffix:1
 # Verify the entire project
 verify:
 	find . -name '*.dfy' | xargs -n 1 -P $(CORES) -I % dafny \
-		-vcsCores:2 \
+		-vcsCores:1 \
 		-compile:0 \
 		-definiteAssignment:3 \
 		-quantifierSyntax:3 \

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -68,15 +68,15 @@ COMPILE_SUFFIX_OPTION := -compileSuffix:1
 # { if cpus >= 3 then 2 else 1 }
 
 # function DAFNY_PROCESSES(cpus: nat): nat
-# { (cpus + 1)/Z3_PROCESSES(cpus) }
+# { (cpus )/Z3_PROCESSES(cpus) }
 
 # lemma Correct(cpus:nat)
-#   ensures DAFNY_PROCESSES(cpus) * Z3_PROCESSES(cpus) <= cpus + 1
+#   ensures DAFNY_PROCESSES(cpus) * Z3_PROCESSES(cpus) <= cpus
 # {}
 
 # Verify the entire project
 verify:Z3_PROCESSES=$(shell echo $$(( $(CORES) >= 3 ? 2 : 1 )))
-verify:DAFNY_PROCESSES=$(shell echo $$(( ($(CORES) + 1 ) / ($(CORES) >= 3 ? 2 : 1))))
+verify:DAFNY_PROCESSES=$(shell echo $$(( ($(CORES) ) / ($(CORES) >= 3 ? 2 : 1))))
 verify:
 	find . -name '*.dfy' | xargs -n 1 -P $(DAFNY_PROCESSES) -I % dafny \
 		-vcsCores:$(Z3_PROCESSES) \

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -65,8 +65,8 @@ COMPILE_SUFFIX_OPTION := -compileSuffix:1
 
 # Verify the entire project
 verify:
-	dafny \
-		-vcsCores:$(CORES) \
+	find . -name '*.dfy' | xargs -n 1 -P $(CORES) -I % dafny \
+		-vcsCores:2 \
 		-compile:0 \
 		-definiteAssignment:3 \
 		-quantifierSyntax:3 \
@@ -75,7 +75,7 @@ verify:
 		-verificationLogger:csv \
 		-timeLimit:100 \
 		-trace \
-		`find . -name *.dfy`
+		%
 
 # Verify single file FILE with text logger.
 # This is useful for debugging resource count usage within a file.

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -64,19 +64,20 @@ COMPILE_SUFFIX_OPTION := -compileSuffix:1
 ########################## Dafny targets
 
 # Proof of correctness for the math below
-# function Z3_PROCESSES(cpus:nat): nat
-# { if cpus >= 3 then 2 else 1 }
+#  function Z3_PROCESSES(cpus:nat): nat
+#  { if cpus >= 3 then 2 else 1 }
 
-# function DAFNY_PROCESSES(cpus: nat): nat
-# { (cpus )/Z3_PROCESSES(cpus) }
+#  function DAFNY_PROCESSES(cpus: nat): nat
+#   requires 0 < cpus // 0 cpus would do no work!
+#  { (cpus - 1 )/Z3_PROCESSES(cpus) }
 
-# lemma Correct(cpus:nat)
-#   ensures DAFNY_PROCESSES(cpus) * Z3_PROCESSES(cpus) <= cpus
-# {}
+#  lemma Correct(cpus:nat)
+#    ensures DAFNY_PROCESSES(cpus) * Z3_PROCESSES(cpus) <= cpus
+#  {}
 
 # Verify the entire project
 verify:Z3_PROCESSES=$(shell echo $$(( $(CORES) >= 3 ? 2 : 1 )))
-verify:DAFNY_PROCESSES=$(shell echo $$(( ($(CORES) ) / ($(CORES) >= 3 ? 2 : 1))))
+verify:DAFNY_PROCESSES=$(shell echo $$(( ($(CORES) - 1 ) / ($(CORES) >= 3 ? 2 : 1))))
 verify:
 	find . -name '*.dfy' | xargs -n 1 -P $(DAFNY_PROCESSES) -I % dafny \
 		-vcsCores:$(Z3_PROCESSES) \

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -63,10 +63,23 @@ COMPILE_SUFFIX_OPTION := -compileSuffix:1
 
 ########################## Dafny targets
 
+# Proof of correctness for the math below
+# function Z3_PROCESSES(cpus:nat): nat
+# { if cpus >= 3 then 2 else 1 }
+
+# function DAFNY_PROCESSES(cpus: nat): nat
+# { (cpus + 1)/Z3_PROCESSES(cpus) }
+
+# lemma Correct(cpus:nat)
+#   ensures DAFNY_PROCESSES(cpus) * Z3_PROCESSES(cpus) <= cpus + 1
+# {}
+
 # Verify the entire project
+verify:Z3_PROCESSES=$(shell echo $$(( $(CORES) >= 3 ? 2 : 1 )))
+verify:DAFNY_PROCESSES=$(shell echo $$(( ($(CORES) + 1 ) / ($(CORES) >= 3 ? 2 : 1))))
 verify:
-	find . -name '*.dfy' | xargs -n 1 -P $(CORES) -I % dafny \
-		-vcsCores:1 \
+	find . -name '*.dfy' | xargs -n 1 -P $(DAFNY_PROCESSES) -I % dafny \
+		-vcsCores:$(Z3_PROCESSES) \
 		-compile:0 \
 		-definiteAssignment:3 \
 		-quantifierSyntax:3 \
@@ -81,7 +94,6 @@ verify:
 # This is useful for debugging resource count usage within a file.
 # Use PROC to further scope the verification
 verify_single:
-	@: $(if ${CORES},,CORES=2);
 	dafny \
 		-vcsCores:$(CORES) \
 		-compile:0 \

--- a/StandardLibrary/src/Base64.dfy
+++ b/StandardLibrary/src/Base64.dfy
@@ -378,6 +378,7 @@ module Base64 {
       if s == [] {
       } else if Is1Padding(suffix) {
         assert !Is2Padding(suffix);
+        assert |prefix| % 4 == 0;
         var x, y := DecodeUnpadded(prefix), Decode1Padding(suffix);
         assert b == x + y;
         assert |x| == |x| / 3 * 3 && |y| == 2;

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -58,9 +58,12 @@ module Base64Lemmas {
       Encode(DecodeValid(s));
     ==
       assert |DecodeValid(s)| % 3 == 2;
+      assert 2 <= |DecodeValid(s)|;
       EncodeUnpadded(DecodeValid(s)[..(|DecodeValid(s)| - 2)]) + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
     == { DecodeValidUnpaddedPartialFrom1PaddedSeq(s); }
-      assert IsUnpaddedBase64String(s[..(|s| - 4)]);
+      assert IsUnpaddedBase64String(s[..(|s| - 4)]) by {
+        assert |s| % 4 == 0;
+      }
       EncodeUnpadded(DecodeUnpadded(s[..(|s| - 4)])) + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
     == { DecodeEncodeUnpadded(s[..(|s| - 4)]); }
       s[..(|s| - 4)] + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);


### PR DESCRIPTION
The Dafny process does not
parallelize very well.

The vcsCores option controls
the number of Z3 processes,
not the number of processes handling parsing.

As such the MPL spends a long time
chewing processing files.
Breaking this up is less efficient,
but may be faster.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

