### PR TITLE
chore: Update CI for .Net Framework

### DIFF
--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -73,29 +73,22 @@ jobs:
           CORES=$(node -e 'console.log(os.cpus().length)')
           make transpile_net CORES=$CORES
 
+      // .NET Framework is only supported in Windows
       - name: Test ${{ matrix.library }} .NET Framework net48
+        if: matrix.os == 'windows-latest'
         working-directory: ./${{ matrix.library }}
         shell: bash
         run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-              DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib" 
-              dotnet run \
-                  --project runtimes/net/tests/ \
-                  --framework net48
-            else
-              dotnet run \
-                  --project runtimes/net/tests/ \
-                  --framework net48
-            fi
+          make test_net FRAMEWORK=net48
 
-      - name: Test ${{ matrix.library }}
+      - name: Test ${{ matrix.library }} .NET net6.0
         working-directory: ./${{ matrix.library }}
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
-            make test_net_mac_intel
+            make test_net_mac_intel FRAMEWORK=net6.0
           else
-            make test_net
+            make test_net FRAMEWORK=net6.0
           fi
 
       - name: Test Cache Thread Safety

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -73,7 +73,7 @@ jobs:
           CORES=$(node -e 'console.log(os.cpus().length)')
           make transpile_net CORES=$CORES
 
-      // .NET Framework is only supported in Windows
+      # .NET Framework is only supported in Windows
       - name: Test ${{ matrix.library }} .NET Framework net48
         if: matrix.os == 'windows-latest'
         working-directory: ./${{ matrix.library }}

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -307,20 +307,23 @@ transpile_test_net: _transpile_test_all
 transpile_dependencies_net: LANG=net
 transpile_dependencies_net: transpile_dependencies
 
+test_net_mac_brew: FRAMEWORK=net6.0
 test_net:
 	dotnet run \
 		--project runtimes/net/tests/ \
-		--framework net6.0
+		--framework $(FRAMEWORK)
 
+test_net_mac_brew: FRAMEWORK=net6.0
 test_net_mac_intel:
 	DYLD_LIBRARY_PATH="/usr/local/opt/openssl@1.1/lib" dotnet run \
 		--project runtimes/net/tests/ \
-		--framework net6.0
+		--framework $(FRAMEWORK)
 
+test_net_mac_brew: FRAMEWORK=net6.0
 test_net_mac_brew:
 	DYLD_LIBRARY_PATH="$(shell brew --prefix)/opt/openssl@1.1/lib/" dotnet run \
 		--project runtimes/net/tests/ \
-		--framework net6.0
+		--framework $(FRAMEWORK)
 
 setup_net:
 	dotnet restore runtimes/net/


### PR DESCRIPTION
The .Net framework is only supported
in windows.

Also, update the SharedMakefile
to consolidate passing the framework.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

