### PR TITLE
fix: Forward the underlying error

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/MultiKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/MultiKeyring.dfy
@@ -171,8 +171,8 @@ module MultiKeyring {
           //= aws-encryption-sdk-specification/framework/multi-keyring.md#onencrypt
           //# - If the generator keyring fails OnEncrypt, this OnEncrypt MUST also
           //# fail.
-        :- Need(onEncryptOutput.Success?,
-                Types.AwsCryptographicMaterialProvidersException( message := "Generator keyring failed to generate plaintext data key"));
+        :- Need(onEncryptOutput.Success?, 
+          if onEncryptOutput.Failure? then onEncryptOutput.error else Types.AwsCryptographicMaterialProvidersException( message := "Unexpected failure. input to Need is !Success.") );
 
           //= aws-encryption-sdk-specification/framework/multi-keyring.md#onencrypt
           //# - If the generator keyring returns encryption materials missing a

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/MultiKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/MultiKeyring.dfy
@@ -171,8 +171,8 @@ module MultiKeyring {
           //= aws-encryption-sdk-specification/framework/multi-keyring.md#onencrypt
           //# - If the generator keyring fails OnEncrypt, this OnEncrypt MUST also
           //# fail.
-        :- Need(onEncryptOutput.Success?, 
-          if onEncryptOutput.Failure? then onEncryptOutput.error else Types.AwsCryptographicMaterialProvidersException( message := "Unexpected failure. input to Need is !Success.") );
+        :- Need(onEncryptOutput.Success?,
+                if onEncryptOutput.Failure? then onEncryptOutput.error else Types.AwsCryptographicMaterialProvidersException( message := "Unexpected failure. input to Need is !Success.") );
 
           //= aws-encryption-sdk-specification/framework/multi-keyring.md#onencrypt
           //# - If the generator keyring returns encryption materials missing a

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/MultiKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/MultiKeyring.dfy
@@ -172,7 +172,7 @@ module MultiKeyring {
           //# - If the generator keyring fails OnEncrypt, this OnEncrypt MUST also
           //# fail.
         :- Need(onEncryptOutput.Success?,
-                if onEncryptOutput.Failure? then onEncryptOutput.error else Types.AwsCryptographicMaterialProvidersException( message := "Unexpected failure. input to Need is !Success.") );
+                if onEncryptOutput.Failure? then onEncryptOutput.error else Types.AwsCryptographicMaterialProvidersException( message := "Unexpected failure. Input to Need is !Success.") );
 
           //= aws-encryption-sdk-specification/framework/multi-keyring.md#onencrypt
           //# - If the generator keyring returns encryption materials missing a


### PR DESCRIPTION
By returning the underlying error,
customers can more clearly see
why the generator failed.

This is especially important for the KMSRsa keyring.
Because it does not support signature suites.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

