### PR TITLE
fix: Empty string defers to SDK default region

### DIFF
--- a/ComAmazonawsKms/runtimes/java/src/main/java/software/amazon/cryptography/services/kms/internaldafny/__default.java
+++ b/ComAmazonawsKms/runtimes/java/src/main/java/software/amazon/cryptography/services/kms/internaldafny/__default.java
@@ -53,9 +53,15 @@ public class __default
     final DafnySequence<? extends Character> region
   ) {
     try {
-      final String regionString = new String(
-        (char[]) region.toArray().unwrap()
-      );
+      final char[] inputRegion = (char[]) region.toArray().unwrap();
+      // The ESDK uses empty string as a kind of none.
+      // In the case of an AWS KMS raw key identifier there is no region element
+      // an so "" is used in this case.
+      if (inputRegion.length == 0) {
+        return KMSClient();
+      }
+
+      final String regionString = new String(inputRegion);
       final KmsClientBuilder builder = KmsClient.builder();
       final KmsClient client = builder
         .region(Region.of(regionString))

--- a/ComAmazonawsKms/runtimes/net/Extern/KMSClient.cs
+++ b/ComAmazonawsKms/runtimes/net/Extern/KMSClient.cs
@@ -39,6 +39,10 @@ namespace software.amazon.cryptography.services.kms.internaldafny
           )
         {
             string regionStr = TypeConversion.FromDafny_N6_smithy__N3_api__S6_String(regionDafnyString);
+            // The ESDK uses empty string as a kind of none.
+            // In the case of an AWS KMS raw key identifier there is no region element
+            // an so "" is used in this case.
+            if (regionStr == "") return KMSClient();
             var region = RegionEndpoint.GetBySystemName(regionStr);
             var client = new DefaultKmsClient(region);
 

--- a/ComAmazonawsKms/test/TestComAmazonawsKms.dfy
+++ b/ComAmazonawsKms/test/TestComAmazonawsKms.dfy
@@ -85,7 +85,7 @@ module TestComAmazonawsKms {
     nameonly expectedKeyId: Kms.Types.KeyIdType
   )
   {
-    var client :- expect Kms.KMSClient();
+    var client :- expect Kms.KMSClientForRegion(TEST_REGION);
 
     var ret := client.Decrypt(input);
 
@@ -106,7 +106,7 @@ module TestComAmazonawsKms {
   )
     requires input.NumberOfBytes.Some?
   {
-    var client :- expect Kms.KMSClient();
+    var client :- expect Kms.KMSClientForRegion(TEST_REGION);
 
     var ret := client.GenerateDataKey(input);
 
@@ -138,7 +138,7 @@ module TestComAmazonawsKms {
     nameonly input: Kms.Types.EncryptRequest
   )
   {
-    var client :- expect Kms.KMSClient();
+    var client :- expect Kms.KMSClientForRegion(TEST_REGION);
 
     var ret := client.Encrypt(input);
 
@@ -167,9 +167,14 @@ module TestComAmazonawsKms {
   // While we cannot easily test that the expected implementations
   // return Some(), we can at least ensure that the ones that do are correct.
   method {:test} RegionMatchTest() {
-    var client :- expect Kms.KMSClient();
+    var client :- expect Kms.KMSClientForRegion(TEST_REGION);
     var region := Kms.RegionMatch(client, TEST_REGION);
     expect region.None? || region.value;
+  }
+
+  // This should default to whatever default SDK uses.
+  method {:test} EmptyStringIsDefaultRegion() {
+    var client :- expect Kms.KMSClientForRegion("");
   }
 
 }


### PR DESCRIPTION
The ESDK will pass an empty string
as the AWS region in cases where no region is know.

In this case we defer to the SDK
on how to evaluate the default region.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
